### PR TITLE
ci: run ruby inside docker

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - ci
 
 jobs:
   github-pages:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           docker build . --tag "chombo:latest"
           mkdir __build
-          id=$(docker create "czombo:latest")
+          id=$(docker create "chombo:latest")
           docker cp "$id:/usr/share/nginx/html/." ./__build
           docker rm -v $id
       - name: Deploy

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -5,13 +5,23 @@ on:
   push:
     branches:
       - master
+      - ci
 
 jobs:
   github-pages:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: helaili/jekyll-action@v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Build website
+        run: |
+          docker build . --tag "chombo:latest"
+          mkdir __build
+          id=$(docker create "czombo:latest")
+          docker cp "$id:/usr/share/nginx/html/." ./__build
+          docker rm -v $id
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
         with:
-          token: ${{ secrets.GHTOKEN }}
-          pre_build_commands: gem update --system
+          github_token: ${{ secrets.GHTOKEN }}
+          publish_dir: ./__build


### PR DESCRIPTION
There was a hidden dependency in `jekyll-action` which blocked us from bumping Ruby version.