### PR TITLE
refactor: switch biggus-tablus from id to class

### DIFF
--- a/_posts/2022-07-09-krakow-mers-open.markdown
+++ b/_posts/2022-07-09-krakow-mers-open.markdown
@@ -150,7 +150,7 @@ z uczestników turnieju, zgodnie z kolejnością zgłoszeń.
 	</div>
 </div>
 
-<center id="biggus-tablus" markdown="block">
+<center class="biggus-tablus" markdown="block">
 
 | Nr | Nazwa                        | Kraj            |
 |---:|:-----------------------------|:----------------|

--- a/_posts/2023-10-06-hatsumi-taikai.markdown
+++ b/_posts/2023-10-06-hatsumi-taikai.markdown
@@ -61,7 +61,7 @@ Dostępna wkrótce!
 	</div>
 </div>
 
-<div id="biggus-tablus" markdown="block">
+<div class="biggus-tablus" markdown="block">
 
 | Nr | Imię i nazwisko                          | Kraj                 | EMA ID                                                              |
 |---:|:-----------------------------------------|:---------------------|:--------------------------------------------------------------------|

--- a/_posts/en/2022-07-09-krakow-mers-open.markdown
+++ b/_posts/en/2022-07-09-krakow-mers-open.markdown
@@ -153,7 +153,7 @@ from the tournament, in the order of submissions.
 	</div>
 </div>
 
-<center id="biggus-tablus" markdown="block">
+<center class="biggus-tablus" markdown="block">
 
 | No. | Name                         | Country       |
 |----:|:-----------------------------|:--------------|

--- a/_posts/en/2023-10-06-hatsumi-taikai.markdown
+++ b/_posts/en/2023-10-06-hatsumi-taikai.markdown
@@ -61,7 +61,7 @@ Coming soon!
 	</div>
 </div>
 
-<div id="biggus-tablus" markdown="block">
+<div class="biggus-tablus" markdown="block">
 
 | Nr | Name                                     | Country              | EMA ID                                                              |
 |---:|:-----------------------------------------|:---------------------|:--------------------------------------------------------------------|

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -54,7 +54,7 @@ address {
   font-style: normal;
 }
 
-#biggus-tablus table {
+.biggus-tablus table {
   width: 100%;
 
   td, th {


### PR DESCRIPTION
This will allow more than one on a page in a clean way, which will prove useful very soon with the waiting list on the Hatsumi Taikai page.