### PR TITLE
Stop using personal GitHub token

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -24,5 +24,5 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         if: github.ref == 'refs/heads/master'
         with:
-          github_token: ${{ secrets.GHTOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./__build


### PR DESCRIPTION
I believe it's leftover from using Travis a few years ago.