### PR TITLE
fix: hide mahjong set buying guide in EN version of the site

### DIFF
--- a/_posts/2024-12-13-how-to-buy-mahjong-set.markdown
+++ b/_posts/2024-12-13-how-to-buy-mahjong-set.markdown
@@ -3,6 +3,7 @@ title: "Kupowanie zestawu do mahjonga — jak wybrać ten najlepszy?"
 date: 2024-12-13 14:00:00 +0100
 categories: other
 lang: pl
+lang-exclusive: ["pl"]
 ---
 
 Ostatnimi czasy najczęściej zadawanymi pytaniami - zarówno na naszym serwerze na Discordzie, w wiadomościach na Facebooku oraz mailowo – są te poruszające kwestie, gdzie można kupić zestaw do mahjonga, ile kosztuje takowy oraz jak odróżnić zestaw do mahjonga japońskiego od innych. Wspólnie postanowiliśmy stworzyć poradnik, który powinien w pewnym stopniu rozjaśnić te frapujące kwestie.


### PR DESCRIPTION
As per https://github.com/untra/polyglot?tab=readme-ov-file#exclusive-site-language-generation.

Tested locally:
![image](https://github.com/user-attachments/assets/674693da-2fbc-4643-8feb-b9eb3a0f3b92)

![image](https://github.com/user-attachments/assets/77d60a25-e2dd-4592-9dbf-f998d36b9132)